### PR TITLE
Add hospital beds and patient chart

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,6 +11,7 @@
     <ChartByClusterContainer />
     <ChartByStatusContainer />
     <ChartByAgeContainer />
+    <ChartByCapacityContainer />
     <MapByCity />
     <Footer />
   </div>
@@ -20,6 +21,7 @@ import ChartByAgeContainer from "./components/ChartByAgeContainer.vue";
 import ChartByDateContainer from "./components/ChartByDateContainer.vue";
 import ChartByClusterContainer from "./components/ChartByClusterContainer.vue";
 import ChartByStatusContainer from "./components/ChartByStatusContainer.vue";
+import ChartByCapacityContainer from "./components/ChartByCapacityContainer.vue";
 import LocaleSwitch from "./components/LocaleSwitch.vue";
 import MapByCity from "./components/MapByCity.vue";
 import Footer from "./components/Footer.vue";
@@ -31,6 +33,7 @@ export default {
     ChartByDateContainer,
     ChartByClusterContainer,
     ChartByStatusContainer,
+    ChartByCapacityContainer,
     LocaleSwitch,
     MapByCity,
     Footer

--- a/src/components/ChartByCapacityContainer.vue
+++ b/src/components/ChartByCapacityContainer.vue
@@ -43,7 +43,7 @@ export default {
         labels: this.dateLabels,
         datasets: [
           {
-            label: this.$t("capacity.labels.totalBed"),
+            label: this.$t("capacity.labels.beds"),
             backgroundColor: "#ffffff",
             fill: false,
             borderColor: "#77aaff",
@@ -53,7 +53,7 @@ export default {
             data: this.capacity
           },
           {
-            label: this.$t("capacity.labels.nonsevere"),
+            label: this.$t("capacity.labels.nonSevere"),
             backgroundColor: "#42b983",
             data: this.nonSevere
           },

--- a/src/components/ChartByCapacityContainer.vue
+++ b/src/components/ChartByCapacityContainer.vue
@@ -1,0 +1,190 @@
+<template>
+  <div class="container">
+    <h2>{{ $t("capacity.title") }}</h2>
+    <loading :active.sync="loading"></loading>
+    <chart-by-capacity
+      v-if="loaded"
+      class="chart"
+      :chart-data="chartdata"
+      :options="options"
+    />
+  </div>
+</template>
+
+<script>
+import axios from "axios";
+import ChartByCapacity from "./BarChart.vue";
+import Loading from "vue-loading-overlay";
+
+export default {
+  name: "ChartByCapacityContainer",
+  components: { ChartByCapacity, Loading },
+  data: () => ({
+    chartdata: null,
+    capacity: [],
+    dateLabels: [],
+    nonSevere: [],
+    severe: [],
+    discharged: [],
+    loaded: false,
+    loading: true
+  }),
+  watch: {
+    "$i18n.locale": function() {
+      this.setChartData();
+    }
+  },
+  async mounted() {
+    this.getData();
+  },
+  methods: {
+    setChartData: function() {
+      this.chartdata = {
+        labels: this.dateLabels,
+        datasets: [
+          {
+            label: this.$t("capacity.labels.totalBed"),
+            backgroundColor: "#ffffff",
+            fill: false,
+            borderColor: "#77aaff",
+            borderWidth: 3,
+            type: "line",
+            lineTension: 0,
+            data: this.capacity
+          },
+          {
+            label: this.$t("capacity.labels.nonsevere"),
+            backgroundColor: "#42b983",
+            data: this.nonSevere
+          },
+          {
+            label: this.$t("capacity.labels.severe"),
+            backgroundColor: "#194531",
+            data: this.severe
+          },
+          {
+            label: this.$t("capacity.labels.discharged"),
+            backgroundColor: "#aaddff",
+            data: this.discharged
+          }
+        ]
+      };
+    },
+    getData: function() {
+      axios
+        .get(
+          "https://spreadsheets.google.com/feeds/cells/" +
+            "1B0aXcDc2IOkKRcWqoQzVsswoJ-rd5hXp8DYgT9KyqDw" +
+            "/5/public/basic?alt=json"
+        )
+        .then(response => {
+          const responseData = response.data;
+
+          const entries = responseData.feed.entry;
+
+          for (let i = 0; i < entries.length; i++) {
+            if (entries[i]["title"]["$t"].substring(0, 1) == "A") {
+              if (!isNaN(entries[i]["content"]["$t"].substring(0, 4))) {
+                this.dateLabels.push(entries[i]["content"]["$t"]);
+              }
+            }
+          }
+
+          const nonSevereCases = entries.filter(entry => {
+            return entry["title"]["$t"].substring(0, 1) == "E";
+          });
+          this.nonSevere = nonSevereCases.map(c => c["content"]["$t"]);
+          this.nonSevere.shift();
+
+          const severeCases = entries.filter(entry => {
+            return entry["title"]["$t"].substring(0, 1) == "F";
+          });
+          this.severe = severeCases.map(c => c["content"]["$t"]);
+          this.severe.shift();
+
+          const dischargedCases = entries.filter(entry => {
+            return entry["title"]["$t"].substring(0, 1) == "H";
+          });
+          this.discharged = dischargedCases.map(c => c["content"]["$t"] * -1);
+          this.discharged.shift();
+
+          const capacityCount = entries.filter(entry => {
+            return entry["title"]["$t"].substring(0, 1) == "H";
+          });
+          this.capacity = capacityCount.map(c => c["content"]["$t"] * 0 + 246);
+          this.capacity.shift();
+
+          this.setChartData();
+
+          this.options = {
+            maintainAspectRatio: false,
+            responsive: true,
+            elements: {
+              point: {
+                radius: 0
+              }
+            },
+            scales: {
+              xAxes: [
+                {
+                  stacked: true,
+                  ticks: {
+                    reverse: true
+                  }
+                }
+              ],
+              yAxes: [
+                {
+                  stacked: true,
+                  ticks: {
+                    suggestedMin: -80,
+                    beginAtZero: true
+                  }
+                }
+              ]
+            }
+          };
+          this.loaded = true;
+          this.loading = false;
+        })
+        .catch(error => {
+          console.log(error);
+        });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.container {
+  margin: 20px auto;
+  padding: 20px 0 50px;
+}
+
+.chart {
+  padding: 0;
+  margin: 0 auto;
+}
+
+@media only screen and (max-width: 800px) {
+  .container {
+    min-height: 300px;
+  }
+
+  .chart {
+    width: 90vw;
+    height: 300px;
+  }
+}
+
+@media only screen and (min-width: 800px) {
+  .container {
+    min-height: 50vh;
+  }
+
+  .chart {
+    width: 50vw;
+    height: 50vh;
+  }
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,6 +81,15 @@
     "title": "Cumulative cases by city",
     "tip": "Hover or tap on a circle marker in the map to view details."
   },
+  "capacity":{
+    "title": "Hospitalized patients and prepared beds",
+    "labels": {
+      "beds": "Beds for COVID-19",
+      "nonSevere": "Non-severe",
+      "severe": "Severe",
+      "discharged": "Discharged total"
+    }
+  },
   "footer": {
     "share": "Share this page",
     "caption": "In celebration of the human brain, and pasta",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -72,6 +72,15 @@
     "title": "自治体別総数",
     "tip": "タップまたはカーソルを合わせると詳細が表示されます。"
   },
+  "capacity":{
+    "title": "入院者数と対応病床数",
+    "labels": {
+      "beds": "COVID-19対応ベッド数",
+      "nonSevere": "軽症",
+      "severe": "重症",
+      "discharged": "退院者 総計"
+    }
+  },
   "footer": {
     "caption": "In celebration of the human brain, and pasta",
     "share": "このページをシェアする",


### PR DESCRIPTION
![2020-04-04_21h46_52](https://user-images.githubusercontent.com/14228487/78451036-db65cd80-76bd-11ea-8c31-299d305bf63e.png)

The latest infomation about beds for COVID-19 is 246, at March 24, by Hyogo Prefecture.
PDF https://web.pref.hyogo.lg.jp/kk03/documents/corona200324-2-1_1.pdf
This data is only in PDF and not announced daily.

Please fix Google spreadsheet like this.
Or can I help update sheet?
https://docs.google.com/spreadsheets/d/1bn8vLTfP7CGqM8PrymMaYWr9T42b6L4LfIz51e9IEIw/edit#gid=1494793560

P.S Hyogo prefecture aims to secure 500 beds with infectious disease prevention measures taken in April.
